### PR TITLE
Fix accessing Widget after being disposed

### DIFF
--- a/lib/pages/delays.dart
+++ b/lib/pages/delays.dart
@@ -55,7 +55,11 @@ class _DelaysState extends State<Delays> {
       _isLoaded = true;
       _hasError = true;
       _errorMessage = 'Ocorreu um erro. Por favor tenta novamente.';
-      setState(() {});
+
+      // Necessary to check ´mounted´ to avoid accessing the widget after disposed
+      if (this.mounted) {
+        setState(() {});
+      }
     }
   }
 


### PR DESCRIPTION
Verifiquei que ao navegar a aplicação por vezes ao voltar para trás, ficava não responsiva.

É devido a falta da verificação `this.mounted` antes de de actualizar o estado através de `setState(() {});`.

Ao navegar do ecrã 'Atrasos' para o do 'Suprimidos'. O `http.get()` lança um erro e tenta actualizar o estado.

O Widget em questão estava a tentar actualizar o estado de algo que já tinha sido `disposed`.

Isto pode ser melhorado através de uma melhor verificação do trabalho interrompido.